### PR TITLE
Use idToken claims instead of UserInfo on Profile page

### DIFF
--- a/src/components/Profile.vue
+++ b/src/components/Profile.vue
@@ -58,7 +58,8 @@ export default {
     }
   },
   async created () {
-    this.claims = await Object.entries(await this.$auth.getUser()).map(entry => ({ claim: entry[0], value: entry[1] }))
+    const idToken = await this.$auth.tokenManager.get('idToken')
+    this.claims = await Object.entries(idToken.claims).map(entry => ({ claim: entry[0], value: entry[1] }))
   }
 }
 </script>


### PR DESCRIPTION
The "My User Profile (ID Token Claims)" does not actually contain all of the claims in the Id Token.